### PR TITLE
segment_image 점대칭 및 label별 color 특정

### DIFF
--- a/ext/nnstreamer/tensor_decoder/meson.build
+++ b/ext/nnstreamer/tensor_decoder/meson.build
@@ -91,3 +91,26 @@ static_library('nnstreamer_decoder_pose_estimation',
   install: true,
   install_dir: nnstreamer_libdir
 )
+
+# image segmentation
+decoder_sub_image_segment_sources = [
+  'tensordec-imagesegment.c'
+]
+
+nnstreamer_decoder_image_segment_sources = []
+foreach s : decoder_sub_image_segment_sources
+  nnstreamer_decoder_image_segment_sources += join_paths(meson.current_source_dir(), s)
+endforeach
+
+shared_library('nnstreamer_decoder_image_segment',
+  nnstreamer_decoder_image_segment_sources,
+  dependencies: [nnstreamer_dep, glib_dep, gst_dep],
+  install: true,
+  install_dir: decoder_subplugin_install_dir
+)
+static_library('nnstreamer_decoder_image_segment',
+  nnstreamer_decoder_direct_video_sources,
+  dependencies: [nnstreamer_dep, glib_dep, gst_dep],
+  install: true,
+  install_dir: nnstreamer_libdir
+)

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
@@ -1,0 +1,271 @@
+/**
+ * GStreamer / NNStreamer tensor_decoder subplugin, "direct video"
+ * Copyright (C) 2018 Jijoong Moon <jijoong.moon@samsung.com>
+ * Copyright (C) 2018 MyungJoo Ham <myungjoo.ham@samsung.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ */
+/**
+ * @file	tensordec-directvideo.c
+ * @date	04 Nov 2018
+ * @brief	NNStreamer tensor-decoder subplugin, "direct video",
+ *              which converts tensors to video directly.
+ *
+ * @see		https://github.com/nnsuite/nnstreamer
+ * @author	Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#include <string.h>
+#include <glib.h>
+#include <gst/video/video-format.h>
+#include <nnstreamer_plugin_api_decoder.h>
+#include <nnstreamer_plugin_api.h>
+
+void init_is (void) __attribute__ ((constructor));
+void fini_is (void) __attribute__ ((destructor));
+
+#define TOTAL_LABELS          21
+#define TFLITE_IMAGE_SIZE     257
+#define DETECTION_THRESHOLD   (.5f)
+
+typedef enum
+{
+  TFLITE_IMAGE_SEGMENT = 0,
+  UNKNOWN_IMAGE_SEGMENT,
+} image_segment_modes;
+
+static const char *is_modes[] = {
+  [TFLITE_IMAGE_SEGMENT] = "tflite",
+  NULL,
+};
+
+typedef struct
+{
+  image_segment_modes mode;
+
+  guint width;
+  guint height;
+  guint ***segment_map;
+} image_segments;
+
+static int
+_init_modes (image_segments *idata)
+{
+  if (idata->mode == TFLITE_IMAGE_SEGMENT) {
+    int i;
+    idata->width = TFLITE_IMAGE_SIZE;
+    idata->height = TFLITE_IMAGE_SIZE;
+    idata->segment_map = g_new0 (guint **, TFLITE_IMAGE_SIZE);
+    for (i = 0; i < TFLITE_IMAGE_SIZE; i++) {
+      idata->segment_map[i] = g_new0 (guint *, TFLITE_IMAGE_SIZE);
+    }
+    return TRUE;
+  }
+  return TRUE;
+}
+
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
+static int
+is_init (void **pdata)
+{
+  image_segments *idata;
+  *pdata = g_new0 (image_segments, 1);
+
+  idata = *pdata;
+  idata->mode = UNKNOWN_IMAGE_SEGMENT;
+  idata->width = 0;
+  idata->height = 0;
+  idata->segment_map = NULL;
+
+  return TRUE;
+}
+
+static void
+_exit_modes (image_segments *idata)
+{
+  if (idata->mode == TFLITE_IMAGE_SEGMENT) {
+  
+  }
+}
+
+static void
+_free_segment_map (image_segments* idata)
+{
+  guint i, j;
+  
+  if (idata->segment_map) {
+    for (i = 0; i < idata->height; i++) {
+      for (j = 0; j < idata->width; j++) {
+        g_free (idata->segment_map[i][j]);
+      }
+      g_free (idata->segment_map[i]);
+    }
+    g_free (idata->segment_map);
+  }
+
+  idata->segment_map = NULL;
+}
+
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
+static void
+is_exit (void **pdata)
+{
+  image_segments *idata = *pdata;
+
+  _free_segment_map (idata);
+  _exit_modes (idata);
+
+  g_free (*pdata);
+  *pdata = NULL;
+}
+
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
+static int
+is_setOption (void **pdata, int opNum, const char *param)
+{
+  image_segments *idata = *pdata;
+  
+  if (opNum == 0) {
+    image_segment_modes previous = idata->mode;
+    idata->mode = find_key_strv (is_modes, param);
+
+    if (NULL == param || *param == '\0') {
+      GST_ERROR ("Please set the valid mode at option1");
+      return FALSE;
+    }
+  
+    if (idata->mode != previous && idata->mode != UNKNOWN_IMAGE_SEGMENT) {
+      g_print("\n\nSet Option\n\n");
+      return _init_modes (idata);
+    }
+    return TRUE;
+  }
+
+  return TRUE;
+}
+
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
+static GstCaps *
+is_getOutCaps (void **pdata, const GstTensorsConfig * config)
+{
+  image_segments *idata = *pdata;
+  gint fn, fd;
+  GstCaps *caps;
+  char *str;
+
+  g_return_val_if_fail (config != NULL, NULL);
+  GST_INFO ("Num Tensors = %d", config->info.num_tensors);
+  g_return_val_if_fail (config->info.num_tensors >= 1, NULL);
+
+  str = g_strdup_printf ("video/x-raw, format = RGB, "
+        "width = %u, height = %u"
+        , idata->width, idata->height);
+  caps = gst_caps_from_string (str);
+
+  fn = config->rate_n; /** @todo Verify if this rate is ok */
+  fd = config->rate_d;
+
+  if (fn >= 0 && fd > 0) {
+    gst_caps_set_simple (caps, "framerate", GST_TYPE_FRACTION, fn, fd, NULL);
+  }
+  g_free (str);
+
+  return gst_caps_simplify (caps);
+}
+
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
+static size_t
+is_getTransformSize (void **pdata, const GstTensorsConfig * config,
+    GstCaps * caps, size_t size, GstCaps * othercaps, GstPadDirection direction)
+{
+  return 0;
+  /** @todo Use appropriate values */
+}
+
+static void
+color (image_segments *idata, GstMapInfo* out_info)
+{
+
+}
+
+static void
+set_segment_map (image_segments *idata, void *data)
+{
+
+}
+
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
+static GstFlowReturn
+is_decode (void **pdata, const GstTensorsConfig * config,
+    const GstTensorMemory * input, GstBuffer * outbuf)
+{
+  image_segments *idata = *pdata;
+  const size_t size = idata->width * idata->height * 3;
+  GstMapInfo out_info;
+  GstMemory *out_mem;
+  
+  g_assert (outbuf);
+  if (gst_buffer_get_size (outbuf) == 0) {
+    out_mem = gst_allocator_alloc (NULL, size, NULL);
+  } else {
+    if (gst_buffer_get_size (outbuf) < size) {
+      gst_buffer_set_size (outbuf, size);
+    }
+    out_mem = gst_buffer_get_all_memory (outbuf);
+  }
+  g_assert (gst_memory_map (out_mem, &out_info, GST_MAP_WRITE));
+
+  memset (out_info.data, 0, size);
+
+  if (idata->mode == TFLITE_IMAGE_SEGMENT) {
+    g_assert (config->info.info[0].type == _NNS_FLOAT32);
+    set_segment_map (idata, input->data);
+  }
+
+  color (idata, &out_info);
+
+  gst_memory_unmap (out_mem, &out_info);
+
+  if (gst_buffer_get_size (outbuf) == 0)
+    gst_buffer_append_memory (outbuf, out_mem);
+
+  return GST_FLOW_OK;
+}
+
+static gchar decoder_subplugin_image_segment[] = "image_segment";
+
+/** @brief Direct-Video tensordec-plugin GstTensorDecoderDef instance */
+static GstTensorDecoderDef imageSegment = {
+  .modename = decoder_subplugin_image_segment,
+  .init = is_init,
+  .exit = is_exit,
+  .setOption = is_setOption,
+  .getOutCaps = is_getOutCaps,
+  .getTransformSize = is_getTransformSize,
+  .decode = is_decode
+};
+
+/** @brief Initialize this object for tensordec-plugin */
+void
+init_is (void)
+{
+  nnstreamer_decoder_probe (&imageSegment);
+}
+
+/** @brief Destruct this object for tensordec-plugin */
+void
+fini_is (void)
+{
+  nnstreamer_decoder_exit (imageSegment.modename);
+}

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
@@ -37,7 +37,7 @@ void fini_is (void) __attribute__ ((destructor));
 
 #define TOTAL_LABELS          21
 #define TFLITE_IMAGE_SIZE     257
-#define DETECTION_THRESHOLD   (0.5f)
+#define DETECTION_THRESHOLD   (.3f)
 
 typedef enum
 {
@@ -159,7 +159,8 @@ is_getOutCaps (void **pdata, const GstTensorsConfig * config)
   gint fn, fd;
   GstCaps *caps;
   char *str;
-
+  idata->width = config->info.info[0].dimension[2];
+  idata->height = config->info.info[0].dimension[1];
   g_return_val_if_fail (config != NULL, NULL);
   GST_INFO ("Num Tensors = %d", config->info.num_tensors);
   g_return_val_if_fail (config->info.num_tensors >= 1, NULL);
@@ -190,21 +191,22 @@ is_getTransformSize (void **pdata, const GstTensorsConfig * config,
 }
 
 static void
-color (image_segments *idata, GstMapInfo* out_info)
+setColorAccourdingToLabel (image_segments *idata, GstMapInfo* out_info)
 {
   uint32_t *frame = (uint32_t *) out_info->data;
   uint32_t *pos;
   int i, j;
-
+  const uint32_t labelColor[21]={
+    0xFF000080, 0xFF800000, 0xFFFFEFD5, 0xFF40E0D0, 0xFFFFA500,
+    0xFF00FF00, 0xFFDC143C, 0xFFF0F8FF, 0xFF008000, 0xFFEE82EE, 
+    0xFF808080, 0xFF4169E1, 0xFF008080, 0xFFFF6347, 0xFF000000, 
+    0xFFFF4500, 0xFFDA70D6, 0xFFEEE8AA, 0xFF98FB98, 0xFFAFEEEE, 
+    0xFFFFF5EE };
   for (i = 0; i < idata->height; i++) {
     for (j = 0; j < idata->width; j++) {
       int label_idx = idata->segment_map[i][j];
       pos = &frame[i*idata->width +j];
-      if (label_idx != 0) {
-        *pos = 0xFF000033;
-      } else {
-        *pos = 0x00000000;
-      }
+      *pos = labelColor[label_idx];
     }
   }
 }
@@ -225,6 +227,7 @@ set_segment_map (image_segments *idata, void *data)
     for (j = 0; j < idata->width; j++) {
       max_idx = 0;
       max_prob = prob_map[i * TOTAL_LABELS + j * idata->width * TOTAL_LABELS];
+      //get index of maximum prob
       for (idx = 1; idx < TOTAL_LABELS; idx++) {
         float prob = prob_map[i * TOTAL_LABELS + j * idata->width * TOTAL_LABELS + idx];
         if (prob > max_prob) {
@@ -268,7 +271,7 @@ is_decode (void **pdata, const GstTensorsConfig * config,
     set_segment_map (idata, input->data);
   }
 
-  color (idata, &out_info);
+  setColorAccourdingToLabel (idata, &out_info);
 
   gst_memory_unmap (out_mem, &out_info);
 

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
@@ -37,7 +37,7 @@ void fini_is (void) __attribute__ ((destructor));
 
 #define TOTAL_LABELS          21
 #define TFLITE_IMAGE_SIZE     257
-#define DETECTION_THRESHOLD   (.5f)
+#define DETECTION_THRESHOLD   (0.5f)
 
 typedef enum
 {
@@ -233,7 +233,7 @@ set_segment_map (image_segments *idata, void *data)
         }
       }
       if (max_prob > DETECTION_THRESHOLD) {
-        idata->segment_map[i][j] = max_idx;
+        idata->segment_map[j][i] = max_idx;
       }
     }
   }


### PR DESCRIPTION
오늘 오전에 진행했전 커밋 두개 PR 합니다.

1. 점대칭 : seg_image의 [i][j]를 [j][i]로 바꿔서 점대칭 시켰습니다.
2. label color : 가장 높은 확률을 가진 컬러 하나만 색칠하게 되어 있는 부분을, 각 픽셀이 어떤 클래스인지에 따라서 257*257 전체를 모두 색칠하는 것으로 바꾸었습니다.