### PR TITLE
[Decoder] Set color according to label index of each pixel

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagesegment.c
@@ -190,21 +190,22 @@ is_getTransformSize (void **pdata, const GstTensorsConfig * config,
 }
 
 static void
-color (image_segments *idata, GstMapInfo* out_info)
+setColorAccourdingToLabel (image_segments *idata, GstMapInfo* out_info)
 {
   uint32_t *frame = (uint32_t *) out_info->data;
   uint32_t *pos;
   int i, j;
-
+  const uint32_t labelColor[21]={
+    0xFF000080, 0xFF800000, 0xFFFFEFD5, 0xFF40E0D0, 0xFFFFA500,
+    0xFF00FF00, 0xFFDC143C, 0xFFF0F8FF, 0xFF008000, 0xFFEE82EE, 
+    0xFF808080, 0xFF4169E1, 0xFF008080, 0xFFFF6347, 0xFF000000, 
+    0xFFFF4500, 0xFFDA70D6, 0xFFEEE8AA, 0xFF98FB98, 0xFFAFEEEE, 
+    0xFFFFF5EE };
   for (i = 0; i < idata->height; i++) {
     for (j = 0; j < idata->width; j++) {
       int label_idx = idata->segment_map[i][j];
       pos = &frame[i*idata->width +j];
-      if (label_idx != 0) {
-        *pos = 0x88000033;
-      } else {
-        *pos = 0x00000000;
-      }
+      *pos = labelColor[label_idx];
     }
   }
 }
@@ -268,7 +269,7 @@ is_decode (void **pdata, const GstTensorsConfig * config,
     set_segment_map (idata, input->data);
   }
 
-  color (idata, &out_info);
+  setColorAccourdingToLabel (idata, &out_info);
 
   gst_memory_unmap (out_mem, &out_info);
 


### PR DESCRIPTION
각 픽셀별로 저장한 label_idx를 사용해서 21개 color 중 하나를 색칠합니다.

아래 pipeline에서 동작 확인했습니다.

```
#!/usr/bin/env bash
gst-launch-1.0 -v \
      filesrc location=dog1.jpeg ! jpegdec ! videoconvert ! videoscale ! imagefreeze !\
      video/x-raw,format=RGB,width=257,height=257,framerate=1/1 ! tee name=t \
      t. ! tensor_converter !\
      tensor_transform mode=arithmetic option=typecast:float32,add:0.0,div:255.0 !\
      tensor_filter framework=tensorflow-lite model=deeplabv3_257_mv_gpu.tflite !\
      tensor_decoder mode=image_segment option1=tflite !\
      compositor name=mix sink_0::zorder=2 sink_1::zorder=0 !\
      videoconvert ! autovideosink \
      t. ! queue ! mix.
```

Signed-off-by: niklasjang <niklasjang@gmail.com>